### PR TITLE
Update type and name of VST3_CATEGORIES for templated impl Vst3Plugin

### DIFF
--- a/{{ cookiecutter.project_name }}/src/lib.rs
+++ b/{{ cookiecutter.project_name }}/src/lib.rs
@@ -143,9 +143,10 @@ impl ClapPlugin for {{ cookiecutter.struct_name }} {
 impl Vst3Plugin for {{ cookiecutter.struct_name }} {
     const VST3_CLASS_ID: [u8; 16] = *b"{{ cookiecutter.vst3_id }}";
 
-    // And don't forget to change these categories, see the docstring on `VST3_CATEGORIES` for more
+    // And don't forget to change these categories, see the docstring on `VST3_SUBCATEGORIES` for more
     // information
-    const VST3_CATEGORIES: &'static str = "Fx|Dynamics";
+    const VST3_SUBCATEGORIES: &'static [Vst3SubCategory] =
+        &[Vst3SubCategory::Fx, Vst3SubCategory::Dynamics];
 }
 
 nih_export_clap!({{ cookiecutter.struct_name }});


### PR DESCRIPTION
This allows the user to immediately build their plugin as a VST3 after _cookiecutter_-ing the template.

After using this template today, I found the existing `impl Vst3Plugin for  {{ cookiecutter.struct_name }}` needed to be changed from `VST3_CATEGORIES: &'static str` to `VST3_SUBCATEGORIES: &'static [Vst3SubCategory]` to match the current definition of `Vst3Plugin`.

I used the current version of the [example gain plugin](https://github.com/robbert-vdh/nih-plug/blob/master/plugins/examples/gain/src/lib.rs) as reference, but kept this template's original given subcategories ("Fx" and "Dynamics" instead of _Gain_'s current "Fx" and "Tools") .

