### PR TITLE
fix template to match renamed arg in `nih-plug`

### DIFF
--- a/{{ cookiecutter.project_name }}/src/lib.rs
+++ b/{{ cookiecutter.project_name }}/src/lib.rs
@@ -101,7 +101,7 @@ impl Plugin for {{ cookiecutter.struct_name }} {
 
     fn initialize(
         &mut self,
-        _bus_config: &BusConfig,
+        _bus_config: &AudioIOLayout,
         _buffer_config: &BufferConfig,
         _context: &mut impl InitContext<Self>,
     ) -> bool {


### PR DESCRIPTION
Template wasn't fully updated after this change: https://github.com/robbert-vdh/nih-plug/commit/e8fd18ab8083e427ffc11996615b94ff4919b2bb