### PR TITLE
Feature choose editor gui

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -8,6 +8,12 @@
   "description": "A short description of your plugin",
   "clap_id": "com.your-domain.{{ cookiecutter.project_name|replace('_', '-') }}",
   "vst3_id": "Exactly16Chars!!",
+  "editor_gui_framework": [
+  	"none",
+  	"Vizia"
+  ],
+  "__nogui": "{{ cookiecutter.editor_gui_framework == 'none' }}",
+  "__vizia": "{{ cookiecutter.editor_gui_framework == 'Vizia' }}",
   "license": [
     "GPL-3.0-or-later",
     "ISC",

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -9,11 +9,13 @@
   "clap_id": "com.your-domain.{{ cookiecutter.project_name|replace('_', '-') }}",
   "vst3_id": "Exactly16Chars!!",
   "editor_gui_framework": [
-  	"none",
-  	"Vizia"
+    "none",
+    "Vizia",
+    "Iced"
   ],
   "__nogui": "{{ cookiecutter.editor_gui_framework == 'none' }}",
   "__vizia": "{{ cookiecutter.editor_gui_framework == 'Vizia' }}",
+  "__iced": "{{ cookiecutter.editor_gui_framework == 'Iced' }}",
   "license": [
     "GPL-3.0-or-later",
     "ISC",

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -4,7 +4,8 @@ import os
 # key value pairs from source location to destination location,
 # also lets you rename files if you want
 MOVE_PATHS = {
-    {% if cookiecutter.__vizia == "True" %}"_editors/_editor-vizia.rs": "src/editor.rs"{% endif %}
+    {% if cookiecutter.__vizia == "True" %}"_editors/_editor-vizia.rs": "src/editor.rs",{% endif %}
+    {% if cookiecutter.__iced == "True" %}"_editors/_editor-iced.rs": "src/editor.rs",{% endif %}
 }
 
 DELETE_PATHS = [

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,0 +1,21 @@
+from shutil import rmtree, move
+import os
+
+# key value pairs from source location to destination location,
+# also lets you rename files if you want
+MOVE_PATHS = {
+    {% if cookiecutter.__vizia == "True" %}"_editors/_editor-vizia.rs": "src/editor.rs"{% endif %}
+}
+
+DELETE_PATHS = [
+    "_editors"
+]
+
+for src, dst in MOVE_PATHS.items():
+    move(src, dst)
+
+for path in DELETE_PATHS:
+    if os.path.isdir(path):
+        rmtree(path)
+    else:
+        os.remove(path)

--- a/{{ cookiecutter.project_name }}/Cargo.toml
+++ b/{{ cookiecutter.project_name }}/Cargo.toml
@@ -24,6 +24,10 @@ nih_plug = { git = "https://github.com/robbert-vdh/nih-plug.git", features = ["a
 nih_plug_vizia = { git = "https://github.com/robbert-vdh/nih-plug.git" }
 {%- endif %}
 
+{% if cookiecutter.__nogui == "False" -%}
+atomic_float = "0.1"
+{%- endif %}
+
 
 [profile.release]
 lto = "thin"

--- a/{{ cookiecutter.project_name }}/Cargo.toml
+++ b/{{ cookiecutter.project_name }}/Cargo.toml
@@ -23,6 +23,10 @@ nih_plug = { git = "https://github.com/robbert-vdh/nih-plug.git", features = ["a
 {% if cookiecutter.__vizia == "True" -%}
 nih_plug_vizia = { git = "https://github.com/robbert-vdh/nih-plug.git" }
 {%- endif %}
+{% if cookiecutter.__iced == "True" -%}
+nih_plug_iced = { git = "https://github.com/robbert-vdh/nih-plug.git" }
+{%- endif %}
+
 
 {% if cookiecutter.__nogui == "False" -%}
 atomic_float = "0.1"

--- a/{{ cookiecutter.project_name }}/Cargo.toml
+++ b/{{ cookiecutter.project_name }}/Cargo.toml
@@ -20,6 +20,10 @@ nih_plug = { git = "https://github.com/robbert-vdh/nih-plug.git", features = ["a
 # Uncomment the below line to disable the on-by-default VST3 feature to remove
 # the GPL compatibility requirement
 # nih_plug = { git = "https://github.com/robbert-vdh/nih-plug.git", default_features = false, features = ["assert_process_allocs"] }
+{% if cookiecutter.__vizia == "True" -%}
+nih_plug_vizia = { git = "https://github.com/robbert-vdh/nih-plug.git" }
+{%- endif %}
+
 
 [profile.release]
 lto = "thin"

--- a/{{ cookiecutter.project_name }}/_editors/README.md
+++ b/{{ cookiecutter.project_name }}/_editors/README.md
@@ -1,0 +1,1 @@
+These files are optionally added to the project if the user desires to.

--- a/{{ cookiecutter.project_name }}/_editors/_editor-iced.rs
+++ b/{{ cookiecutter.project_name }}/_editors/_editor-iced.rs
@@ -1,11 +1,10 @@
-use atomic_float::AtomicF32;
-use nih_plug::prelude::{util, Editor, GuiContext};
+use nih_plug::prelude::{Editor, GuiContext};
 use nih_plug_iced::widgets as nih_widgets;
 use nih_plug_iced::*;
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::GainParams;
+use crate::{{ cookiecutter.struct_name }}Params;
 
 // Makes sense to also define this here, makes it a bit easier to keep track of
 pub(crate) fn default_state() -> Arc<IcedState> {
@@ -13,14 +12,14 @@ pub(crate) fn default_state() -> Arc<IcedState> {
 }
 
 pub(crate) fn create(
-    params: Arc<GainParams>,
+    params: Arc<{{ cookiecutter.struct_name }}Params>,
     editor_state: Arc<IcedState>,
 ) -> Option<Box<dyn Editor>> {
-    create_iced_editor::<GainEditor>(editor_state, (params,))
+    create_iced_editor::<{{ cookiecutter.struct_name }}Editor>(editor_state, (params,))
 }
 
-struct GainEditor {
-    params: Arc<GainParams>,
+struct {{ cookiecutter.struct_name }}Editor {
+    params: Arc<{{ cookiecutter.struct_name }}Params>,
     context: Arc<dyn GuiContext>,
 
     gain_slider_state: nih_widgets::param_slider::State,
@@ -32,16 +31,16 @@ enum Message {
     ParamUpdate(nih_widgets::ParamMessage),
 }
 
-impl IcedEditor for GainEditor {
+impl IcedEditor for {{ cookiecutter.struct_name }}Editor {
     type Executor = executor::Default;
     type Message = Message;
-    type InitializationFlags = (Arc<GainParams>, Arc<AtomicF32>);
+    type InitializationFlags = (Arc<{{ cookiecutter.struct_name }}Params>, Arc<AtomicF32>);
 
     fn new(
         (params,): Self::InitializationFlags,
         context: Arc<dyn GuiContext>,
     ) -> (Self, Command<Self::Message>) {
-        let editor = GainEditor {
+        let editor = {{ cookiecutter.struct_name }}Editor {
             params,
             context,
 
@@ -71,7 +70,7 @@ impl IcedEditor for GainEditor {
         Column::new()
             .align_items(Alignment::Center)
             .push(
-                Text::new("Gain GUI")
+                Text::new("{{ cookiecutter.struct_name }} GUI")
                     .font(assets::NOTO_SANS_LIGHT)
                     .size(40)
                     .height(50.into())

--- a/{{ cookiecutter.project_name }}/_editors/_editor-iced.rs
+++ b/{{ cookiecutter.project_name }}/_editors/_editor-iced.rs
@@ -1,0 +1,104 @@
+use atomic_float::AtomicF32;
+use nih_plug::prelude::{util, Editor, GuiContext};
+use nih_plug_iced::widgets as nih_widgets;
+use nih_plug_iced::*;
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::GainParams;
+
+// Makes sense to also define this here, makes it a bit easier to keep track of
+pub(crate) fn default_state() -> Arc<IcedState> {
+    IcedState::from_size(200, 150)
+}
+
+pub(crate) fn create(
+    params: Arc<GainParams>,
+    editor_state: Arc<IcedState>,
+) -> Option<Box<dyn Editor>> {
+    create_iced_editor::<GainEditor>(editor_state, (params,))
+}
+
+struct GainEditor {
+    params: Arc<GainParams>,
+    context: Arc<dyn GuiContext>,
+
+    gain_slider_state: nih_widgets::param_slider::State,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Message {
+    /// Update a parameter's value.
+    ParamUpdate(nih_widgets::ParamMessage),
+}
+
+impl IcedEditor for GainEditor {
+    type Executor = executor::Default;
+    type Message = Message;
+    type InitializationFlags = (Arc<GainParams>, Arc<AtomicF32>);
+
+    fn new(
+        (params,): Self::InitializationFlags,
+        context: Arc<dyn GuiContext>,
+    ) -> (Self, Command<Self::Message>) {
+        let editor = GainEditor {
+            params,
+            context,
+
+            gain_slider_state: Default::default(),
+        };
+
+        (editor, Command::none())
+    }
+
+    fn context(&self) -> &dyn GuiContext {
+        self.context.as_ref()
+    }
+
+    fn update(
+        &mut self,
+        _window: &mut WindowQueue,
+        message: Self::Message,
+    ) -> Command<Self::Message> {
+        match message {
+            Message::ParamUpdate(message) => self.handle_param_message(message),
+        }
+
+        Command::none()
+    }
+
+    fn view(&mut self) -> Element<'_, Self::Message> {
+        Column::new()
+            .align_items(Alignment::Center)
+            .push(
+                Text::new("Gain GUI")
+                    .font(assets::NOTO_SANS_LIGHT)
+                    .size(40)
+                    .height(50.into())
+                    .width(Length::Fill)
+                    .horizontal_alignment(alignment::Horizontal::Center)
+                    .vertical_alignment(alignment::Vertical::Bottom),
+            )
+            .push(
+                Text::new("Gain")
+                    .height(20.into())
+                    .width(Length::Fill)
+                    .horizontal_alignment(alignment::Horizontal::Center)
+                    .vertical_alignment(alignment::Vertical::Center),
+            )
+            .push(
+                nih_widgets::ParamSlider::new(&mut self.gain_slider_state, &self.params.gain)
+                    .map(Message::ParamUpdate),
+            )
+            .into()
+    }
+
+    fn background_color(&self) -> nih_plug_iced::Color {
+        nih_plug_iced::Color {
+            r: 0.98,
+            g: 0.98,
+            b: 0.98,
+            a: 1.0,
+        }
+    }
+}

--- a/{{ cookiecutter.project_name }}/_editors/_editor-vizia.rs
+++ b/{{ cookiecutter.project_name }}/_editors/_editor-vizia.rs
@@ -1,18 +1,14 @@
-use atomic_float::AtomicF32;
-use nih_plug::prelude::{util, Editor};
+use nih_plug::prelude::Editor;
 use nih_plug_vizia::vizia::prelude::*;
 use nih_plug_vizia::widgets::*;
 use nih_plug_vizia::{assets, create_vizia_editor, ViziaState, ViziaTheming};
-use std::sync::atomic::Ordering;
 use std::sync::Arc;
-use std::time::Duration;
 
-use crate::GainParams;
+use crate::{{ cookiecutter.struct_name }}Params;
 
 #[derive(Lens)]
 struct Data {
-    params: Arc<GainParams>,
-    peak_meter: Arc<AtomicF32>,
+    params: Arc<{{ cookiecutter.struct_name }}Params>,
 }
 
 impl Model for Data {}
@@ -23,7 +19,7 @@ pub(crate) fn default_state() -> Arc<ViziaState> {
 }
 
 pub(crate) fn create(
-    params: Arc<GainParams>,
+    params: Arc<{{ cookiecutter.struct_name }}Params>,
     editor_state: Arc<ViziaState>,
 ) -> Option<Box<dyn Editor>> {
     create_vizia_editor(editor_state, ViziaTheming::Custom, move |cx, _| {
@@ -38,7 +34,7 @@ pub(crate) fn create(
         ResizeHandle::new(cx);
 
         VStack::new(cx, |cx| {
-            Label::new(cx, "Gain GUI")
+            Label::new(cx, "{{ cookiecutter.struct_name }} GUI")
                 .font_family(vec![FamilyOwned::Name(String::from(
                     assets::NOTO_SANS_THIN,
                 ))])

--- a/{{ cookiecutter.project_name }}/_editors/_editor-vizia.rs
+++ b/{{ cookiecutter.project_name }}/_editors/_editor-vizia.rs
@@ -1,0 +1,57 @@
+use atomic_float::AtomicF32;
+use nih_plug::prelude::{util, Editor};
+use nih_plug_vizia::vizia::prelude::*;
+use nih_plug_vizia::widgets::*;
+use nih_plug_vizia::{assets, create_vizia_editor, ViziaState, ViziaTheming};
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::GainParams;
+
+#[derive(Lens)]
+struct Data {
+    params: Arc<GainParams>,
+    peak_meter: Arc<AtomicF32>,
+}
+
+impl Model for Data {}
+
+// Makes sense to also define this here, makes it a bit easier to keep track of
+pub(crate) fn default_state() -> Arc<ViziaState> {
+    ViziaState::new(|| (200, 150))
+}
+
+pub(crate) fn create(
+    params: Arc<GainParams>,
+    editor_state: Arc<ViziaState>,
+) -> Option<Box<dyn Editor>> {
+    create_vizia_editor(editor_state, ViziaTheming::Custom, move |cx, _| {
+        assets::register_noto_sans_light(cx);
+        assets::register_noto_sans_thin(cx);
+
+        Data {
+            params: params.clone(),
+        }
+        .build(cx);
+
+        ResizeHandle::new(cx);
+
+        VStack::new(cx, |cx| {
+            Label::new(cx, "Gain GUI")
+                .font_family(vec![FamilyOwned::Name(String::from(
+                    assets::NOTO_SANS_THIN,
+                ))])
+                .font_size(30.0)
+                .height(Pixels(50.0))
+                .child_top(Stretch(1.0))
+                .child_bottom(Pixels(0.0));
+
+            Label::new(cx, "Gain");
+            ParamSlider::new(cx, Data::params, |params| &params.gain);
+        })
+        .row_between(Pixels(0.0))
+        .child_left(Stretch(1.0))
+        .child_right(Stretch(1.0));
+    })
+}

--- a/{{ cookiecutter.project_name }}/src/lib.rs
+++ b/{{ cookiecutter.project_name }}/src/lib.rs
@@ -6,6 +6,9 @@ use atomic_float::AtomicF32;
 {% if cookiecutter.__vizia == "True" -%}
 use nih_plug_vizia::ViziaState;
 {%- endif %}
+{% if cookiecutter.__iced == "True" -%}
+use nih_plug_iced::IcedState;
+{%- endif %}
 
 // This is a shortened version of the gain example with most comments removed, check out
 // https://github.com/robbert-vdh/nih-plug/blob/master/plugins/examples/gain/src/lib.rs to get
@@ -27,6 +30,12 @@ struct {{ cookiecutter.struct_name }}Params {
     #[persist = "editor-state"]
     editor_state: Arc<ViziaState>,
     {%- endif %}
+    {% if cookiecutter.__iced == "True" -%}
+    /// The editor state, saved together with the parameter state so the custom scaling can be
+    /// restored.
+    #[persist = "editor-state"]
+    editor_state: Arc<IcedState>,
+    {%- endif %}
 
     /// The parameter's ID is used to identify the parameter in the wrappred plugin API. As long as
     /// these IDs remain constant, you can rename and reorder these fields as you wish. The
@@ -47,7 +56,7 @@ impl Default for {{ cookiecutter.struct_name }} {
 impl Default for {{ cookiecutter.struct_name }}Params {
     fn default() -> Self {
         Self {
-            {% if cookiecutter.__vizia == "True" -%}
+            {% if cookiecutter.__nogui == "False" -%}
                 editor_state: editor::default_state(),
             {%- endif %}
 
@@ -120,7 +129,7 @@ impl Plugin for {{ cookiecutter.struct_name }} {
         self.params.clone()
     }
 
-    {% if cookiecutter.__vizia == "True" -%}
+    {% if cookiecutter.__nogui == "False" -%}
     fn editor(&mut self, _async_executor: AsyncExecutor<Self>) -> Option<Box<dyn Editor>> {
         editor::create(
             self.params.clone(),

--- a/{{ cookiecutter.project_name }}/src/lib.rs
+++ b/{{ cookiecutter.project_name }}/src/lib.rs
@@ -1,8 +1,5 @@
 use nih_plug::prelude::*;
 use std::sync::Arc;
-{% if cookiecutter.__nogui == "False" -%}
-use atomic_float::AtomicF32;
-{%- endif %}
 {% if cookiecutter.__vizia == "True" -%}
 use nih_plug_vizia::ViziaState;
 {%- endif %}


### PR DESCRIPTION
Adding support for optionally generating editor code for Vizia and Iced.

Changes:
- Add an additional parameter to the template to pick a GUI framework, or no GUI
- Add code generation for minimal Vizia editor
- Add code generation for minimal Iced editor
- Add hooks to remove unnecessary files after generation, for instance, removing the Vizia editor implementation if Iced is chosen, or remove both editor implementations if no GUI is chosen.
