### PR TITLE
fix: Git dependencies not downloading correctly

### DIFF
--- a/{{ cookiecutter.project_name }}/.cargo/config
+++ b/{{ cookiecutter.project_name }}/.cargo/config
@@ -1,2 +1,5 @@
 [alias]
 xtask = "run --package xtask --release --"
+
+[net]
+git-fetch-with-cli = true


### PR DESCRIPTION
Hi ! 

When I used this template, I could not download the git-based dependencies on my system (macOS, rust 1.77.1), unless I modified the cargo config like this. Now it works great.

Thanks.